### PR TITLE
Add removing signature checks in newer builds

### DIFF
--- a/Patcher/Program.cs
+++ b/Patcher/Program.cs
@@ -76,6 +76,7 @@ namespace Patcher
                         break;
                     case "--remove-signature-check":
                         config.RemoveSignatureCheck = true;
+                        break;
                     case "--remove-certificate-check":
                         config.RemoveCertificateCheck = true;
                         break;

--- a/Patcher/Program.cs
+++ b/Patcher/Program.cs
@@ -34,6 +34,7 @@ namespace Patcher
             Console.WriteLine("  --deobfuscate              Automatically deobfuscate the binary with de4dot");
             Console.WriteLine("  --fix-netlib               Fix issues with netlib data encoding");
             Console.WriteLine("  --mscorlib-path            Specify your path to mscorlib.dll");
+            Console.WriteLine("  --remove-signature-check   Remove osu!.exe signature check");
             Console.WriteLine("  --remove-certificate-check Remove certificate pinning checks");
             Console.WriteLine("  --help                     Show this help message and exit");
             Environment.Exit(0);

--- a/Patcher/Program.cs
+++ b/Patcher/Program.cs
@@ -481,7 +481,7 @@ namespace Patcher
                     "/usr/lib/mono/4.6/",
                     "/usr/lib/mono/4.5.2/",
                     "/usr/lib/mono/4.5.1/",
-                    "/usr/lib/mono/4.5/", #=zDSqYo2WV2n3gGImYeHrzDoc=::#=zIAq1Tpg=
+                    "/usr/lib/mono/4.5/",
                     "/usr/lib/mono/4.0/",
                     "/usr/lib/mono/3.5/",
                     "/usr/lib/mono/3.0/",


### PR DESCRIPTION
This will append `return true;` at the beginning of the method responsible for checking the executable signature.